### PR TITLE
Improve Japanese translation

### DIFF
--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -3,10 +3,10 @@
     "message": "常にシアターモードを使用する"
   },
   "anyPercent": {
-    "message": "どれでも ％"
+    "message": "割合によらず"
   },
   "auto": {
-    "message": "オート"
+    "message": "自動"
   },
   "desktopOnly": {
     "message": "デスクトップのみ"
@@ -18,13 +18,13 @@
     "message": "ホームフィードを無効にする"
   },
   "disableHomeFeedNote": {
-    "message": "ログインしている場合のみ - サブスクリプションにリダイレクト"
+    "message": "ログイン時に登録チャンネルへリダイレクト"
   },
   "downloadTranscript": {
     "message": "文字起こしをダウンロード可能にする"
   },
   "embeddedVideos": {
-    "message": "埋め込まれた動画"
+    "message": "埋め込み動画"
   },
   "enabled": {
     "message": "有効"
@@ -33,13 +33,13 @@
     "message": "実験的な機能"
   },
   "extensionDescription": {
-    "message": "不足しているオプションとUIの改善を追加して、YouTubeをより制御できるようにします"
+    "message": "YouTubeに不足しているオプションやUIの改善を追加し、より自由にカスタマイズできるようにします"
   },
   "extensionName": {
     "message": "Control Panel for YouTube"
   },
   "features": {
-    "message": "特徴"
+    "message": "機能"
   },
   "fullSizeTheaterMode": {
     "message": "フルサイズシアターモード"
@@ -54,13 +54,13 @@
     }
   },
   "hideAI": {
-    "message": "AI概要を非表示"
+    "message": "AIによる概要を非表示"
   },
   "hideChannels": {
     "message": "チャンネルを非表示"
   },
   "hideChannelsNote": {
-    "message": "ビデオメニューに「チャンネルを隠す」を追加します"
+    "message": "動画メニューに「チャンネルを非表示」オプションを追加"
   },
   "hideChat": {
     "message": "チャットを非表示"
@@ -75,25 +75,25 @@
     "message": "共有ボタンを非表示"
   },
   "hideEndCards": {
-    "message": "ビデオのエンドカードを非表示"
+    "message": "動画のエンドカードを非表示"
   },
   "hideEndVideos": {
-    "message": "ビデオのエンドスクリーンのコンテンツを非表示"
+    "message": "動画の終了画面を非表示"
   },
   "hideExploreButton": {
-    "message": "ホームで探索ボタンを非表示"
+    "message": "ホームで検索ボタンを非表示"
   },
   "hideHiddenVideos": {
     "message": "非表示にされた動画を非表示"
   },
   "hideHiddenVideosNote": {
-    "message": "5秒後に「元に戻す」ボタンを非表示にします"
+    "message": "「元に戻す」ボタンを5秒後に非表示"
   },
   "hideHomeCategories": {
     "message": "ホームのカテゴリを非表示"
   },
   "hideInfoPanels": {
-    "message": "情報パネルを非表示にする"
+    "message": "情報パネルを非表示"
   },
   "hideLive": {
     "message": "ライブ動画を非表示"
@@ -102,16 +102,16 @@
     "message": "商品、オファーなどを非表示"
   },
   "hideMetadata": {
-    "message": "ビデオのメタデータを非表示"
+    "message": "動画のメタデータを非表示"
   },
   "hideMiniplayerButton": {
-    "message": "ミニプレイヤー非表示ボタン"
+    "message": "ミニプレイヤーボタンを非表示"
   },
   "hideMixes": {
     "message": "ミックスを非表示"
   },
   "hideMoviesAndTV": {
-    "message": "の映画とテレビ番組非表示"
+    "message": "映画とテレビを非表示"
   },
   "hideNextButton": {
     "message": "次へボタンを非表示"
@@ -132,19 +132,19 @@
     "message": "ショート動画を非表示"
   },
   "hideSponsored": {
-    "message": "スポンサード動画とプロモーションを非表示"
+    "message": "スポンサー動画とプロモーションを非表示"
   },
   "hideStreamed": {
     "message": "配信済みの動画を非表示"
   },
   "hideSubscriptionsChannelList": {
-    "message": "登録チャンネルのチャンネルリストを非表示にする"
+    "message": "登録チャンネルのチャンネルリストを非表示"
   },
   "hideSubscriptionsLatestBar": {
-    "message": "サブスクリプション内の「新しい順」バーを非表示"
+    "message": "登録チャンネルの「新しい順」バーを非表示"
   },
   "hideSuggestedSections": {
-    "message": "提案されたセクションを非表示"
+    "message": "おすすめセクションを非表示"
   },
   "hideUpcoming": {
     "message": "公開予定の動画を非表示"
@@ -165,28 +165,28 @@
     "message": "中"
   },
   "minimumGridItemsPerRow": {
-    "message": "行あたりの最小グリッド項目数"
+    "message": "1行あたりの最小表示数"
   },
   "minimumGridItemsPerRowNote": {
-    "message": "ホームとサブスクリプション内で"
+    "message": "ホームと登録チャンネルで適用"
   },
   "mobileGridView": {
-    "message": "購読と検索にグリッド ビューを使用する（縦画面のみ）"
+    "message": "購読と検索にグリッドビューを使用する（縦画面のみ）"
   },
   "mobileOnly": {
     "message": "モバイルのみ"
   },
   "pauseChannelTrailers": {
-    "message": "チャンネルのトレーラーを自動的に一時停止する"
+    "message": "チャンネルのトレーラーを自動的に一時停止"
   },
   "redirectShorts": {
     "message": "ショート動画を通常のプレイヤーにリダイレクト"
   },
   "removePink": {
-    "message": "進捗バーからピンク色を削除する"
+    "message": "進捗バーからピンク色を削除"
   },
   "searchThumbnailSize": {
-    "message": "検索サムネイルサイズ"
+    "message": "検索サムネイルのサイズ"
   },
   "shorts": {
     "message": "ショート動画"
@@ -198,15 +198,15 @@
     "message": "小"
   },
   "tidyGuideSidebar": {
-    "message": "整頓されたガイドサイドバー"
+    "message": "サイドバーを整理する"
   },
   "uiTweaks": {
     "message": "UIの微調整"
   },
   "videoLists": {
-    "message": "ビデオリスト"
+    "message": "動画リスト"
   },
   "videoPages": {
-    "message": "ビデオページ"
+    "message": "動画ページ"
   }
 }


### PR DESCRIPTION
## Summary  
- Updated the Japanese translations in `_locales/ja/messages.json` to use more natural, contemporary language that aligns with YouTube’s official Japanese UI terminology.

## Why  
- The previous translations were either too literal or unnatural, leading to inconsistencies with the official YouTube interface.  
- These changes improve clarity and ensure a more intuitive user experience for native Japanese users.

## Files Changed  
- `_locales/ja/messages.json`