### PR TITLE
fix: improve shorts filtering in search results to catch new formats

### DIFF
--- a/content.js
+++ b/content.js
@@ -935,6 +935,12 @@ const configureCss = (() => {
           // List item (except History, so watched Shorts can be removed)
           'ytd-browse:not([page-subtype="history"]) ytd-video-renderer:has(a[href^="/shorts"])',
           'ytd-search ytd-video-renderer:has(a[href^="/shorts"])',
+          // Additional selectors to catch more shorts in search results
+          'ytd-search ytd-reel-item-renderer',
+          'ytd-search ytd-grid-video-renderer:has(a[href^="/shorts"])',
+          'ytd-search ytd-rich-item-renderer:has(a[href^="/shorts"])',
+          'ytd-search ytd-video-renderer:has(.ytd-thumbnail[href^="/shorts"])',
+          'ytd-search ytd-grid-video-renderer:has(.ytd-thumbnail[href^="/shorts"])',
           // Under video
           '#structured-description ytd-reel-shelf-renderer',
           // In related
@@ -954,6 +960,10 @@ const configureCss = (() => {
           'ytm-search lazy-list > ytm-reel-shelf-renderer',
           // Search
           'ytm-search ytm-video-with-context-renderer:has(a[href^="/shorts"])',
+          // Additional selectors for mobile shorts in search
+          'ytm-search ytm-reel-item-renderer',
+          'ytm-search ytm-slim-video-renderer:has(a[href^="/shorts"])',
+          'ytm-search ytm-compact-video-renderer:has(a[href^="/shorts"])',
           // Under video
           'ytm-structured-description-content-renderer ytm-reel-shelf-renderer',
           // In related


### PR DESCRIPTION
## Fix: Improve shorts filtering in search results to catch new formats

This PR addresses issue #73 where shorts were appearing in search results despite the extension being configured to hide them.

### Problem
YouTube has updated how shorts are displayed in search results, using different DOM elements and structure than what the extension was previously targeting. This allowed shorts to "leak through" and appear in search results when they should be hidden.

### Solution
Added more comprehensive CSS selectors to target various ways YouTube displays shorts in search results:

For desktop:
- Added selectors for `ytd-reel-item-renderer` elements
- Added selectors for grid and rich item renderers with shorts links
- Added selectors for different thumbnail containers with shorts links

For mobile:
- Added similar selectors to target mobile-specific elements

### Testing
The fix has been tested on a real YouTube search results page and successfully hides shorts that were previously visible.

### Screenshots
See issue #73 for reference screenshots of the problem.