### PR TITLE
Disable hide playlists in related video suggestions

### DIFF
--- a/page.js
+++ b/page.js
@@ -1174,7 +1174,7 @@ const configureCss = (() => {
           // Home
           'ytd-browse[page-subtype="home"] ytd-rich-item-renderer:has(.yt-lockup-view-model-wiz)',
           // Search and Related
-          ':is(#related, ytd-search) yt-lockup-view-model:has(> .yt-lockup-view-model-wiz)',
+          ':is(ytd-search) yt-lockup-view-model:has(> .yt-lockup-view-model-wiz)',
           // Video endscreen
           '.ytp-videowall-still[data-is-list="true"][data-is-mix="false"]',
         )


### PR DESCRIPTION
Looks like the entire hide videos section is being treated like a playlist? I think that means there aren't even playlists in the related videos anymore. I scrolled for a long time and never saw one so I wasn't able to see what the selectors would look like. I also don't have any experience with extensions so lmk if theres something else needed to make this work but I don't mind if you close the pr and do it yourself
closes #94 closes #95 

also would like to say that this is the best extension ever

I read that deleting a fork doesn't delete the prs associated with it.... thanks internet