### PR TITLE
Fix Hide Live/Streamed selectors for YouTube DOM changes

### DIFF
--- a/page.js
+++ b/page.js
@@ -1040,11 +1040,15 @@ const configureCss = (() => {
           // Grid item (Home, Subscriptions)
           'ytd-browse:not([page-subtype="channels"]) ytd-rich-item-renderer:has(ytd-thumbnail[is-live-video])',
           'ytd-browse:not([page-subtype="channels"]) ytd-rich-item-renderer:has(.badge-shape-wiz--thumbnail-live)',
+          'ytd-browse:not([page-subtype="channels"]) ytd-rich-item-renderer:has(.yt-badge-shape--thumbnail-live)',
           // List item (Search)
           'ytd-video-renderer:has(ytd-thumbnail[is-live-video])',
+          'ytd-video-renderer:has(.yt-badge-shape--thumbnail-live)',
           // Related
           'ytd-compact-video-renderer:has(> .ytd-compact-video-renderer > ytd-thumbnail[is-live-video])',
+          'ytd-compact-video-renderer:has(.yt-badge-shape--thumbnail-live)',
           '#related yt-lockup-view-model:has(.badge-shape-wiz--thumbnail-live)',
+          '#related yt-lockup-view-model:has(.yt-badge-shape--thumbnail-live)',
         )
       }
       if (mobile) {
@@ -3359,7 +3363,7 @@ function manuallyHideVideo($video) {
     if (desktop) {
       let $metadata = /** @type {HTMLElement} */ ($video.querySelector(
         // TODO Remove #metadata-line after confirming all videos have moved to yt-lockup-view-model
-        '#metadata-line, yt-content-metadata-view-model .yt-content-metadata-view-model-wiz__delimiter + .yt-content-metadata-view-model-wiz__metadata-text'
+        '#metadata-line, yt-content-metadata-view-model .yt-content-metadata-view-model-wiz__delimiter + .yt-content-metadata-view-model-wiz__metadata-text, yt-content-metadata-view-model .yt-content-metadata-view-model__delimiter + .yt-content-metadata-view-model__metadata-text'
       ))
       if ($metadata) {
         hide = Boolean($metadata.innerText.match(getString('STREAMED_METADATA_INNERTEXT_RE')))


### PR DESCRIPTION
- Add .yt-badge-shape--thumbnail-live for live videos
- Update streamed metadata selector without -wiz suffix
- Maintain backward compatibility with existing selectors

Fixes #117